### PR TITLE
Add a KoffiFunc<T> helper type in TS typing.

### DIFF
--- a/src/koffi/src/index.d.ts
+++ b/src/koffi/src/index.d.ts
@@ -40,6 +40,15 @@ declare module 'koffi' {
         };
     };
 
+    export type KoffiFunc<T extends (...args: any) => any> = T & {
+       async: (...args: [...Parameters<T>, (err: any, result: ReturnType<T>) => void]) => void;
+       info: {
+          name: string;
+          arguments: IKoffiCType[];
+          result: IKoffiCType;
+       };
+    };
+
     export interface IKoffiLib {
         func(definition: string): KoffiFunction;
         func(name: string, result: TypeSpec, arguments: TypeSpec[]): KoffiFunction;


### PR DESCRIPTION
This allow user code to write something like 

```typescript
const A : KoffiFunc<(a: int) => bool> = ......;

// And then use it like:
A(5) // TS will recognize the param type
A.async(5, (err, result) => {}); // TS will recognize result as number type
```