### PR TITLE
Add missing return type for koffi.array

### DIFF
--- a/src/koffi/src/index.d.ts
+++ b/src/koffi/src/index.d.ts
@@ -81,7 +81,7 @@ declare module 'koffi' {
     export function union(name: string, def: Record<string, TypeSpecWithAlignment>): IKoffiCType;
     export function union(def: Record<string, TypeSpecWithAlignment>): IKoffiCType;
 
-    export function array(ref: TypeSpec, len: number, hint?: ArrayHint | null);
+    export function array(ref: TypeSpec, len: number, hint?: ArrayHint | null): any[];
 
     export function opaque(name: string): IKoffiCType;
     export function opaque(): IKoffiCType;


### PR DESCRIPTION
Hi,

Currently `array` function type declaration is missing return type, which causes a compilation error in TypeScript strict mode.

```
node_modules/koffi/src/koffi/src/index.d.ts:84:21 - error TS7010: 'array', which lacks return-type annotation, implicitly has an 'any' return type.
84     export function array(ref: TypeSpec, len: number, hint?: ArrayHint | null);
                       ~~~~~
```

Can you release a patch fix for this? As it currently breaks all the builds 🤣 