### PR TITLE
Fix the type of `koffi.encode()`

### DIFF
--- a/src/koffi/index.d.ts
+++ b/src/koffi/index.d.ts
@@ -132,7 +132,6 @@ declare module 'koffi' {
     export function decode(value: any, offset: number, type: TypeSpec, len: number): any;
     export function address(value: any): bigint;
     export function call(value: any, type: TypeSpec, ...args: any[]): any;
-    export function encode(ref: any, type: TypeSpec): void;
     export function encode(ref: any, type: TypeSpec, value: any): void;
     export function encode(ref: any, type: TypeSpec, value: any, len: number): void;
     export function encode(ref: any, offset: number, type: TypeSpec): void;


### PR DESCRIPTION
Fix the type of `koffi.encode()`. The third argument should be mandatory.