### PR TITLE
Create release.yml

### DIFF
--- a/.github/scripts/increment-tag.sh
+++ b/.github/scripts/increment-tag.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+PROJECT=$1       # ${{ inputs.project }}
+INPUT_VERSION=$2 # ${{ inputs.version }}
+INCREMENT=$3     # ${{ inputs.increment || 'patch' }}
+
+LATEST_TAG=$(git tag --list --format="%(refname:short)" --sort taggerdate "${PROJECT}*" 2>/dev/null | tail -1)
+LATEST_TAG=$(echo "$LATEST_TAG" | awk -F/ '{print $NF}')
+VERSION=${LATEST_TAG:-0.0.0}
+if [[ -n "${INPUT_VERSION}" ]]; then
+  # Strip 'v' prefix if present
+  VERSION=${INPUT_VERSION#v}
+else
+  # Ensure we have a full semver (pad with .0 if needed)
+  case $(echo "$VERSION" | tr '.' '\n' | wc -l) in
+    1) VERSION="$VERSION.0.0" ;;
+    2) VERSION="$VERSION.0" ;;
+  esac
+  npm install -g semver 2>&1 >/dev/null
+  NEW_VERSION=$(semver -i $INCREMENT $VERSION)
+  VERSION="$NEW_VERSION"
+fi
+echo "version=$VERSION"
+echo "prev_version=${LATEST_TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Build and Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g., v1.0.0) - leave empty to auto-increment"
+        required: false
+        type: string
+      project:
+        description: "Which project to tag"
+        required: true
+        type: choice
+        options:
+          - rekkord
+          - goupile
+          - tytools
+          - meestic
+          #- felix
+          #- heimdall
+      increment:
+        description: "How to increment version if not specified"
+        required: false
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v5
+        with:
+          fetch-depth: 0
+      - name: Determine new version
+        id: version
+        run: |
+          bash .github/scripts/increment-tag.sh \
+            "${{ inputs.project }}" \
+            "${{ inputs.version }}" \
+            "${{ inputs.increment || 'patch' }}" \
+            | tee $GITHUB_OUTPUT
+      - name: Building source tarball for ${{ inputs.project }}
+        run: |
+          export VERSION="${{ steps.version.outputs.version }}"
+          tag="${{ inputs.project }}/${{ steps.version.outputs.version }}"
+
+          sudo apt-get update
+          sudo apt-get install build-essential libudev-dev qt6-base-dev qt6-base-dev-tools qt6-svg-dev
+
+          bash src/${{ inputs.project }}/dist/source/source.sh
+
+          mv bin/Packages/*tar.gz bin/Packages/${{ inputs.project }}-${{ steps.version.outputs.version }}.tar.gz
+          mv bin/Packages/*tar.xz bin/Packages/${{ inputs.project }}-${{ steps.version.outputs.version }}.tar.xz
+      - name: Tag and release
+        run: |
+          tag="${{ inputs.project }}/${{ steps.version.outputs.version }}"
+
+          git tag $tag
+          git push origin $tag
+
+          gh release create $tag \
+            --title "Release $tag" \
+            --notes "Release $tag" \
+            --latest \
+            bin/Packages/*tar*
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/tools/package/build/source/package.sh
+++ b/tools/package/build/source/package.sh
@@ -12,7 +12,8 @@ directories=$(grep -E -o '[|"](lib/native|lib/web|src|vendor)/[a-zA-Z0-9_\-]+/' 
 sources="bootstrap.sh bootstrap.bat FelixBuild.ini.presets ${directories}"
 imports=$(ls "${DEST_DIR}/bin/Log/"*.json | grep -v compile_commands | xargs jq -r '.imports | .[]')
 
-VERSION=$(./felix -pDebug -O "${DEST_DIR}/bin" --run "${VERSION_TARGET}" --version | awk -F'[ ]' "/^${VERSION_TARGET}/ {print \$2}")
+LOCAL_VERSION=$(./felix -pDebug -O "${DEST_DIR}/bin" --run "${VERSION_TARGET}" --version | awk -F'[ ]' "/^${VERSION_TARGET}/ {print \$2}")
+VERSION=${VERSION:-$LOCAL_VERSION}
 TMP_DIR="${DEST_DIR}/${PKG_NAME}_${VERSION}"
 DEST_TAR="../../${PKG_NAME}_${VERSION}_src.tar"
 


### PR DESCRIPTION
closes #93 

In my fork I got a basic github [actions](https://github.com/phanirithvij/rygel/actions/workflows/release.yml) workflow to create [tags](https://github.com/phanirithvij/rygel/tags) and [releases](https://github.com/phanirithvij/rygel/releases) working.

It only supports a `workflow_dispatch` event i.e. manual workflow trigger from the actions tab. (can also use the gh cli like below)

> [!NOTE]
>A repository secret needs to be added in the repo settings, named GH_TOKEN with permission to push tags. Before the workflow can run.

```console
$ gh workflow run release.yml -f project=goupile
$ echo -en "goupile tytools rekkord meestic" | xargs -d' ' -I{} gh workflow run release.yml -f project={}
```

There is another way of doing it, like detecting when a tag has been pushed and build release assets, but I thought this approach was better, as it fails to create a new tag if the build fails. Also it removes the friction and does automatic semver bump.

Please let me know for all the PRs I open what's lacking, and I can address them.
I am sure you are busy, but any reply at all would help me decide how to proceed.